### PR TITLE
Typo Fix: Replace semicolon with comma to fix ReferenceError

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,11 @@ module.exports = ({
     minimumPoints = minimumPoints || 2;
     distanceFunction = distanceFunction || ((a, b) => Math.abs(a - b));
 
-    var visitedIndices = {};
+    var visitedIndices = {},
         isVisited = (i) => ( visitedIndices[i] ),
         markVisited = (i) => { visitedIndices[i] = true };
 
-    var clusteredIndices = {};
+    var clusteredIndices = {},
         isClustered = (i) => ( clusteredIndices[i] ),
         markClustered = (i) => { clusteredIndices[i] = true };
 


### PR DESCRIPTION
Hey Jan - thanks for publishing this module, been using it for a personal project. I ran into this bug though, which is caused by a typo (I believe). 

**Problem:**
Seeing the following error when using this module in the browser (Chrome, up to date):
`Uncaught (in promise) ReferenceError: isVisited is not defined`. 

**Cause**
The variable `isVisited`, `markVisited`, `isClustered`, and `markClustered` are not being declared with the preceding `var` keyword since there is a semicolon instead of a comma in the first variable declaration in their respective statement.

**Fix**
Replace the semicolons with comma. 

**Testing**
I tested this by running the change on my web app which was throwing the error and it fixed it!